### PR TITLE
Use lowercase naming conventions for Linux

### DIFF
--- a/NetatmoTrueTempSync/NetatmoTrueTempSync.csproj
+++ b/NetatmoTrueTempSync/NetatmoTrueTempSync.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <TrimmerRootAssembly Include="NetatmoTrueTempSync" />
+    <TrimmerRootAssembly Include="$(AssemblyName)" />
     <TrimmerRootAssembly Include="Spectre.Console" />
   </ItemGroup>
 

--- a/NetatmoTrueTempSync/Services/SystemdServiceManager.cs
+++ b/NetatmoTrueTempSync/Services/SystemdServiceManager.cs
@@ -4,7 +4,7 @@ namespace NetatmoTrueTempSync.Services;
 
 internal sealed class SystemdServiceManager : IServiceManager
 {
-    private const string UnitName = "com.siewers.NetatmoTrueTempSync";
+    private const string UnitName = "netatmo-truetempsync";
 
     private static readonly string UnitDir = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),

--- a/deploy.sh
+++ b/deploy.sh
@@ -37,7 +37,7 @@ proc run_scp {user host pass src dst} {
 
 send_user "Deploying to $user@$host:$install_dir...\n"
 run_ssh $user $host $pass "sudo mkdir -p $install_dir && sudo chown $user:$user $install_dir"
-run_scp $user $host $pass "$publish_dir/NetatmoTrueTempSync" "$install_dir/"
-run_ssh $user $host $pass "$install_dir/NetatmoTrueTempSync service install"
+run_scp $user $host $pass "$publish_dir/netatmo-truetempsync" "$install_dir/"
+run_ssh $user $host $pass "$install_dir/netatmo-truetempsync service install"
 
 send_user "Done!\n"


### PR DESCRIPTION
## Summary

- Rename systemd unit from `com.siewers.NetatmoTrueTempSync` to `netatmo-truetempsync`
- Publish binary as `netatmo-truetempsync` for linux-arm64 via publish profile
- Use `$(AssemblyName)` for trimmer root to adapt to publish profile overrides
- Update deploy script for new binary name