### PR TITLE
Add GitHub Actions build and release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v5
+
+      - name: Build
+        run: dotnet build -c Release
+
+      - name: Test
+        run: dotnet test -c Release --no-build
+
+      - name: Publish
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: dotnet publish NetatmoTrueTempSync/NetatmoTrueTempSync.csproj -p:PublishProfile=linux-arm64 -p:PublishDir=${{ github.workspace }}/publish
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create ${{ github.ref_name }} publish/* --repo ${{ github.repository }} --generate-notes

--- a/NetatmoTrueTempSync.slnx
+++ b/NetatmoTrueTempSync.slnx
@@ -1,4 +1,7 @@
 <Solution>
   <Project Path="NetatmoTrueTempSync.Tests/NetatmoTrueTempSync.Tests.csproj" />
   <Project Path="NetatmoTrueTempSync/NetatmoTrueTempSync.csproj" />
+  <Folder Name="/.github/workflows/">
+    <File Path=".github/workflows/build.yml" />
+  </Folder>
 </Solution>


### PR DESCRIPTION
## Summary
- Build and test on PRs targeting main
- On version tag pushes (`v*`), also publish a `linux-arm64` binary and create a GitHub Release
- Uses the existing `linux-arm64` publish profile
- Added workflow to solution file

Closes #8

## Test plan
- [ ] Merge PR and verify the build workflow ran
- [ ] Push a `v*` tag and verify a release is created with the binary attached