### PR TITLE
Use assembly version for update version display

### DIFF
--- a/NetatmoTrueTempSync/Services/UpdateService.cs
+++ b/NetatmoTrueTempSync/Services/UpdateService.cs
@@ -14,8 +14,8 @@ public static class UpdateService
 
     public static string? GetCurrentVersion()
     {
-        return Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-            ?? Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
+        var version = Assembly.GetEntryAssembly()?.GetName().Version;
+        return version is not null ? $"v{version.ToString(3)}" : null;
     }
 
     public static async Task<(string? TagName, string? AssetUrl)?> CheckForUpdateAsync(HttpClient client, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- Use `Assembly.GetName().Version.ToString(3)` with `v` prefix instead of informational version
- Output now matches tag format exactly (e.g. `v0.2.1` instead of `0.2.1+hash`)