### PR TITLE
fix: Cap max sync delta to 1°C to prevent temperature overshoot

### DIFF
--- a/NetatmoTrueTempSync.Tests/SyncServiceTests.cs
+++ b/NetatmoTrueTempSync.Tests/SyncServiceTests.cs
@@ -249,6 +249,20 @@ public class SyncServiceTests
         await Assert.That(SyncService.ShouldSync(sensorTemp, valveTemp)).IsEqualTo(expected);
     }
 
+    // --- IsDeltaSafe ---
+
+    [Test]
+    [Arguments(21.0, 21.5, true)]
+    [Arguments(21.0, 22.0, true)]
+    [Arguments(21.0, 20.0, true)]
+    [Arguments(21.0, 22.1, false)]
+    [Arguments(21.0, 19.9, false)]
+    [Arguments(18.0, 22.0, false)]
+    public async Task IsDeltaSafe_respects_max_delta(double sensorTemp, double valveTemp, bool expected)
+    {
+        await Assert.That(SyncService.IsDeltaSafe(sensorTemp, valveTemp)).IsEqualTo(expected);
+    }
+
     // --- FindHome ---
 
     private static readonly List<Home> TestHomes =

--- a/NetatmoTrueTempSync/Commands/SyncCommand.cs
+++ b/NetatmoTrueTempSync/Commands/SyncCommand.cs
@@ -106,6 +106,14 @@ public static class SyncCommand
                 continue;
             }
 
+            if (!SyncService.IsDeltaSafe(sensor.Temperature, valveTemp))
+            {
+                AnsiConsole.MarkupLine(
+                    $"  [bold]{Markup.Escape(room.Name)}[/] — sensor [blue]{Markup.Escape(sensor.Name)}[/] [cyan]{sensor.Temperature:F1}°C[/], valve [yellow]{valveTemp:F1}°C[/] (delta {delta:+0.0;-0.0}°C) [red]skipped — delta too large[/]");
+
+                continue;
+            }
+
             AnsiConsole.MarkupLine(
                 $"  [bold]{Markup.Escape(room.Name)}[/] — sensor [blue]{Markup.Escape(sensor.Name)}[/] [cyan]{sensor.Temperature:F1}°C[/], valve [yellow]{valveTemp:F1}°C[/] (delta {delta:+0.0;-0.0}°C) → [green]{valveNames}[/]");
 

--- a/NetatmoTrueTempSync/Services/SyncService.cs
+++ b/NetatmoTrueTempSync/Services/SyncService.cs
@@ -5,6 +5,7 @@ namespace NetatmoTrueTempSync.Services;
 public static class SyncService
 {
     private const double SyncThreshold = 0.05;
+    private const double MaxDelta = 1.0;
 
     public static List<IndoorReading> ExtractIndoorReadings(IEnumerable<WeatherStation> stations)
     {
@@ -48,6 +49,9 @@ public static class SyncService
 
     public static bool ShouldSync(double sensorTemp, double valveTemp) =>
         Math.Abs(sensorTemp - valveTemp) >= SyncThreshold;
+
+    public static bool IsDeltaSafe(double sensorTemp, double valveTemp) =>
+        Math.Abs(sensorTemp - valveTemp) <= MaxDelta;
 
     public static Home FindHome(List<Home> homes, string? homeName)
     {


### PR DESCRIPTION
## Summary
- Skip temperature sync when the sensor-valve delta exceeds 1°C
- Prevents Netatmo's truetemperature API from overcorrecting during schedule transitions (e.g., night setpoint lowering causes cold radiator → large delta → room overheats to 27°C)
- Adds `IsDeltaSafe` check with parameterized tests

## Test plan
- [x] All 31 tests pass including 6 new `IsDeltaSafe` boundary tests
- [ ] Monitor sync logs for "skipped — delta too large" warnings during schedule transitions
- [ ] Verify room temperature no longer spikes above setpoint after night schedules