### PR TITLE
feat: Add CSV file logging for sync activity

### DIFF
--- a/NetatmoTrueTempSync.Tests/SyncLoggerTests.cs
+++ b/NetatmoTrueTempSync.Tests/SyncLoggerTests.cs
@@ -1,0 +1,121 @@
+using NetatmoTrueTempSync.Services;
+
+namespace NetatmoTrueTempSync.Tests;
+
+public class SyncLoggerTests
+{
+    [Test]
+    public async Task Log_writes_csv_entry()
+    {
+        await using var writer = new StringWriter();
+        await using var logger = new SyncLogger(writer);
+
+        await logger.LogAsync("Living Room", "Sensor1", 21.5, 20.8, SyncAction.Synced);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("Living Room,Sensor1,21.5,20.8,+0.7,synced");
+    }
+
+    [Test]
+    public async Task Log_appends_multiple_entries()
+    {
+        await using var writer = new StringWriter();
+        await using var logger = new SyncLogger(writer);
+
+        await logger.LogAsync("Room1", "S1", 21.0, 20.5, SyncAction.Synced);
+        await logger.LogAsync("Room2", "S2", 22.0, 23.5, SyncAction.DeltaTooLarge);
+        await logger.LogAsync("Room3", "S3", 21.0, 21.0, SyncAction.NoCorrection);
+
+        var lines = writer.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        await Assert.That(lines).Count().IsEqualTo(3);
+        await Assert.That(lines[0]).Contains("synced");
+        await Assert.That(lines[1]).Contains("delta-too-large");
+        await Assert.That(lines[2]).Contains("no-correction");
+    }
+
+    [Test]
+    public async Task Log_escapes_commas_in_room_name()
+    {
+        await using var writer = new StringWriter();
+        await using var logger = new SyncLogger(writer);
+
+        await logger.LogAsync("Room, Main", "Sensor1", 21.0, 20.0, SyncAction.Synced);
+
+        await Assert.That(writer.ToString()).Contains("\"Room, Main\"");
+    }
+
+    [Test]
+    public async Task Log_includes_iso_timestamp()
+    {
+        await using var writer = new StringWriter();
+        await using var logger = new SyncLogger(writer);
+
+        await logger.LogAsync("Room1", "S1", 21.0, 20.0, SyncAction.Synced);
+
+        // ISO 8601 format starts with year
+        var line = writer.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)[0];
+        await Assert.That(line).StartsWith("20");
+    }
+
+    [Test]
+    public async Task Log_formats_negative_delta()
+    {
+        await using var writer = new StringWriter();
+        await using var logger = new SyncLogger(writer);
+
+        await logger.LogAsync("Room1", "S1", 20.0, 21.5, SyncAction.Synced);
+
+        await Assert.That(writer.ToString()).Contains("-1.5");
+    }
+
+    [Test]
+    public async Task CreateForFile_writes_header_to_new_file()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sync-test-{Guid.NewGuid()}.log");
+
+        try
+        {
+            await using (var logger = await SyncLogger.CreateForFileAsync(path))
+            {
+                await logger.LogAsync("Room1", "S1", 21.0, 20.0, SyncAction.Synced);
+            }
+
+            var lines = await File.ReadAllLinesAsync(path);
+
+            await Assert.That(lines[0]).IsEqualTo("Timestamp,Room,Sensor,SensorTemp,ValveTemp,Delta,Action");
+            await Assert.That(lines).Count().IsEqualTo(2);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task CreateForFile_rotates_when_file_exceeds_max_size()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sync-test-{Guid.NewGuid()}.log");
+        var rotatedPath = path + ".1";
+
+        try
+        {
+            await File.WriteAllTextAsync(path, new string('x', 5 * 1024 * 1024 + 1));
+
+            await using (var logger = await SyncLogger.CreateForFileAsync(path))
+            {
+                await logger.LogAsync("Room1", "S1", 21.0, 20.0, SyncAction.Synced);
+            }
+
+            await Assert.That(File.Exists(rotatedPath)).IsTrue();
+
+            var lines = await File.ReadAllLinesAsync(path);
+            await Assert.That(lines).Count().IsEqualTo(2);
+        }
+        finally
+        {
+            File.Delete(path);
+            File.Delete(rotatedPath);
+        }
+    }
+}

--- a/NetatmoTrueTempSync.Tests/SyncLoggerTests.cs
+++ b/NetatmoTrueTempSync.Tests/SyncLoggerTests.cs
@@ -59,6 +59,23 @@ public class SyncLoggerTests
     }
 
     [Test]
+    public async Task Log_uses_same_cycle_id_for_all_entries()
+    {
+        await using var writer = new StringWriter();
+        await using var logger = new SyncLogger(writer);
+
+        await logger.LogAsync("Room1", "S1", 21.0, 20.0, SyncAction.Synced);
+        await logger.LogAsync("Room2", "S2", 22.0, 21.0, SyncAction.Synced);
+
+        var lines = writer.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        var cycleId1 = lines[0].Split(',')[1];
+        var cycleId2 = lines[1].Split(',')[1];
+
+        await Assert.That(cycleId1).IsEqualTo(cycleId2);
+        await Assert.That(cycleId1).Length().IsEqualTo(8);
+    }
+
+    [Test]
     public async Task Log_formats_negative_delta()
     {
         await using var writer = new StringWriter();
@@ -83,7 +100,7 @@ public class SyncLoggerTests
 
             var lines = await File.ReadAllLinesAsync(path);
 
-            await Assert.That(lines[0]).IsEqualTo("Timestamp,Room,Sensor,SensorTemp,ValveTemp,Delta,Action");
+            await Assert.That(lines[0]).IsEqualTo("Timestamp,CycleId,Room,Sensor,SensorTemp,ValveTemp,Delta,Action");
             await Assert.That(lines).Count().IsEqualTo(2);
         }
         finally

--- a/NetatmoTrueTempSync/Commands/SyncCommand.cs
+++ b/NetatmoTrueTempSync/Commands/SyncCommand.cs
@@ -24,6 +24,7 @@ public static class SyncCommand
     {
         var config = await ConfigStore.LoadAsync(cancellationToken);
         using var client = new NetatmoClient(TokenStore.LoadCredentials());
+        await using var logger = await SyncLogger.CreateForFileAsync(ConfigStore.LogPath);
 
         if (dryRun)
         {
@@ -32,7 +33,7 @@ public static class SyncCommand
 
         try
         {
-            await RunSyncCycleAsync(client, dryRun, homeName, config, cancellationToken);
+            await RunSyncCycleAsync(client, dryRun, homeName, config, logger, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -43,7 +44,7 @@ public static class SyncCommand
         return 0;
     }
 
-    private static async Task RunSyncCycleAsync(NetatmoClient client, bool dryRun, string? homeName, AppConfig config, CancellationToken cancellationToken)
+    private static async Task RunSyncCycleAsync(NetatmoClient client, bool dryRun, string? homeName, AppConfig config, SyncLogger logger, CancellationToken cancellationToken)
     {
         var homesData = await client.GetHomesDataAsync(cancellationToken);
         var homes = homesData.Body?.Homes ?? [];
@@ -103,6 +104,7 @@ public static class SyncCommand
                 AnsiConsole.MarkupLine(
                     $"  [bold]{Markup.Escape(room.Name)}[/] — sensor [blue]{Markup.Escape(sensor.Name)}[/] [cyan]{sensor.Temperature:F1}°C[/], valve [yellow]{valveTemp:F1}°C[/] [dim](no correction needed)[/]");
 
+                await logger.LogAsync(room.Name, sensor.Name, sensor.Temperature, valveTemp, SyncAction.NoCorrection);
                 continue;
             }
 
@@ -111,6 +113,7 @@ public static class SyncCommand
                 AnsiConsole.MarkupLine(
                     $"  [bold]{Markup.Escape(room.Name)}[/] — sensor [blue]{Markup.Escape(sensor.Name)}[/] [cyan]{sensor.Temperature:F1}°C[/], valve [yellow]{valveTemp:F1}°C[/] (delta {delta:+0.0;-0.0}°C) [red]skipped — delta too large[/]");
 
+                await logger.LogAsync(room.Name, sensor.Name, sensor.Temperature, valveTemp, SyncAction.DeltaTooLarge);
                 continue;
             }
 
@@ -122,6 +125,7 @@ public static class SyncCommand
                 await client.SetTrueTemperatureAsync(home.Id, room.Id, valveTemp, sensor.Temperature, cancellationToken);
             }
 
+            await logger.LogAsync(room.Name, sensor.Name, sensor.Temperature, valveTemp, SyncAction.Synced);
             syncCount++;
         }
 

--- a/NetatmoTrueTempSync/ConfigStore.cs
+++ b/NetatmoTrueTempSync/ConfigStore.cs
@@ -11,6 +11,11 @@ public static class ConfigStore
 
     private static string ConfigPath => Path.Combine(ConfigDir, "config.json");
 
+    private static readonly string LogDir = Path.Combine(
+        AppContext.BaseDirectory, "logs");
+
+    public static string LogPath => Path.Combine(LogDir, "sync.log");
+
     public static async Task<AppConfig> LoadAsync(CancellationToken cancellationToken = default)
     {
         if (!File.Exists(ConfigPath))

--- a/NetatmoTrueTempSync/Services/SyncLogger.cs
+++ b/NetatmoTrueTempSync/Services/SyncLogger.cs
@@ -1,0 +1,85 @@
+using System.Globalization;
+
+namespace NetatmoTrueTempSync.Services;
+
+public sealed class SyncLogger(TextWriter writer) : IAsyncDisposable
+{
+    private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
+    private const string Header = "Timestamp,Room,Sensor,SensorTemp,ValveTemp,Delta,Action";
+
+    public async Task LogAsync(string room, string sensor, double sensorTemp, double valveTemp, SyncAction action)
+    {
+        var delta = sensorTemp - valveTemp;
+        var timestamp = DateTime.Now.ToString("O", CultureInfo.InvariantCulture);
+
+        await writer.WriteLineAsync(
+            $"{timestamp},{Escape(room)},{Escape(sensor)},{sensorTemp:F1},{valveTemp:F1},{delta:+0.0;-0.0},{action.ToLogString()}");
+
+        await writer.FlushAsync();
+    }
+
+    public async ValueTask DisposeAsync() => await writer.DisposeAsync();
+
+    public static async Task<SyncLogger> CreateForFileAsync(string logPath)
+    {
+        var dir = Path.GetDirectoryName(logPath)!;
+        Directory.CreateDirectory(dir);
+
+        RotateIfNeeded(logPath);
+
+        var isNew = !File.Exists(logPath) || new FileInfo(logPath).Length == 0;
+        var streamWriter = new StreamWriter(logPath, append: true);
+
+        if (isNew)
+        {
+            await streamWriter.WriteLineAsync(Header);
+        }
+
+        return new SyncLogger(streamWriter);
+    }
+
+    private static void RotateIfNeeded(string logPath)
+    {
+        if (!File.Exists(logPath))
+        {
+            return;
+        }
+
+        var info = new FileInfo(logPath);
+        if (info.Length < MaxFileSize)
+        {
+            return;
+        }
+
+        var rotated = logPath + ".1";
+        if (File.Exists(rotated))
+        {
+            File.Delete(rotated);
+        }
+
+        File.Move(logPath, rotated);
+    }
+
+    private static string Escape(string value) =>
+        value.Contains(',') || value.Contains('"')
+            ? $"\"{value.Replace("\"", "\"\"")}\""
+            : value;
+}
+
+public enum SyncAction
+{
+    Synced,
+    NoCorrection,
+    DeltaTooLarge,
+}
+
+public static class SyncActionExtensions
+{
+    public static string ToLogString(this SyncAction action) => action switch
+    {
+        SyncAction.Synced => "synced",
+        SyncAction.NoCorrection => "no-correction",
+        SyncAction.DeltaTooLarge => "delta-too-large",
+        _ => "unknown",
+    };
+}

--- a/NetatmoTrueTempSync/Services/SyncLogger.cs
+++ b/NetatmoTrueTempSync/Services/SyncLogger.cs
@@ -5,7 +5,8 @@ namespace NetatmoTrueTempSync.Services;
 public sealed class SyncLogger(TextWriter writer) : IAsyncDisposable
 {
     private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
-    private const string Header = "Timestamp,Room,Sensor,SensorTemp,ValveTemp,Delta,Action";
+    private const string Header = "Timestamp,CycleId,Room,Sensor,SensorTemp,ValveTemp,Delta,Action";
+    private readonly string _cycleId = Guid.NewGuid().ToString()[..8];
 
     public async Task LogAsync(string room, string sensor, double sensorTemp, double valveTemp, SyncAction action)
     {
@@ -13,7 +14,7 @@ public sealed class SyncLogger(TextWriter writer) : IAsyncDisposable
         var timestamp = DateTime.Now.ToString("O", CultureInfo.InvariantCulture);
 
         await writer.WriteLineAsync(
-            $"{timestamp},{Escape(room)},{Escape(sensor)},{sensorTemp:F1},{valveTemp:F1},{delta:+0.0;-0.0},{action.ToLogString()}");
+            $"{timestamp},{_cycleId},{Escape(room)},{Escape(sensor)},{sensorTemp:F1},{valveTemp:F1},{delta:+0.0;-0.0},{action.ToLogString()}");
 
         await writer.FlushAsync();
     }


### PR DESCRIPTION
## Summary
- Logs each sync result to `<app-dir>/logs/sync.log` as CSV with fields: timestamp, room, sensor, sensor temp, valve temp, delta, action
- Automatic rotation when log exceeds 5 MB (keeps one rotated backup)
- `SyncLogger` accepts a `TextWriter` for testability, with a `CreateForFileAsync` factory for file-based usage

## Test plan
- [x] All 38 tests pass (7 new logger tests, 5 using StringWriter, 2 file-based for header/rotation)
- [ ] Deploy to Pi and verify `logs/sync.log` is created with expected CSV entries
- [ ] Monitor over 24h to observe delta patterns during schedule transitions

Closes #31